### PR TITLE
Release 1.6.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-client" %}
-{% set version = "1.6.3" %}
-{% set checksum = "e24339e172e79554c2045209c54366a39fb37f6ceeede738cde7cb324de464f3" %}
+{% set version = "1.6.5" %}
+{% set checksum = "c2094a42b2021d2aafd063f15f87647b68dcebdd2e7d87c226190b6726ca182e" %}
 
 package:
   name: {{ name }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
@@ -28,6 +28,7 @@ requirements:
   run:
     - python
     - clyent
+    - nbformat
     - requests >=2.9.1
     - pyyaml
     - python-dateutil


### PR DESCRIPTION
```markdown
## Version 1.6.5 (2017/09/08)

### Fixed

* Fixes to allow conda 3 to build
* Removed unused dependency

## Version 1.6.4 (2017/09/08)

### Added

* Add `https://` to domain URL when is missing
* Added `--platform` filter
* Displaying build information on packages table
* Notebook validation on upload
* Warning message when token is about to expire
```