### PR TITLE
Exclude urllib3 v2 due to use of deprecated features in binstar_client

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 60e3bc346e4e4eaf6d97576891bf0c7457b0e32fc7196e806f38ad8fa9356344
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
   entry_points:
@@ -38,7 +38,7 @@ requirements:
     - setuptools >=58.0.4
     - six >=1.15.0
     - tqdm >=4.56.0
-    - urllib3 >=1.26.4
+    - urllib3 >=1.26.4,<2.0.0a
     - anaconda-project >=0.9.1
     - pillow >=8.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - setuptools >=58.0.4
     - six >=1.15.0
     - tqdm >=4.56.0
-    - urllib3 >=1.26.4,<2.0.0a
+    - urllib3 >=1.26.4,<2.0.0a0
     - anaconda-project >=0.9.1
     - pillow >=8.2
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR closes #40 by pinning urllib3 to <v2. The `binstar_client` code in `anaconda-client` relies on features that were deprecated late in v1, and removed in v2.
