### PR TITLE
Release 1.14.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/anaconda-cloud-auth-feedstock/pr19/e67b5eb

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_check: false
+channels:
+  - https://staging.continuum.io/pbp/fs/anaconda-cloud-auth-feedstock/pr19/e67b5eb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
 
   run:
     - python
@@ -47,8 +49,10 @@ test:
     - binstar_client.utils
     - binstar_client.utils.notebook
     - binstar_client.utils.notebook.tests
-
+  requires:
+    - pip
   commands:
+    - pip check
     - anaconda --help
     - binstar --help
     - conda-server --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-client" %}
-{% set version = "1.7.2" %}
-{% set checksum = "839bc07d5e3b9069180ad9c78bfb0b74ab7b4ccac9523a5b9d1d8aa0b154bab5" %}
+{% set version = "1.8.0" %}
+{% set checksum = "be97ef87be4e9076db91c0aaee4a4dc30e2527c8d87c63c8a0c12cd6fd269d95" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-client" %}
 {% set version = "1.7.2" %}
-{% set checksum = "1c832a1d2e4cebe5080862758c8644f1470450577040aa0c840e8eff44fc41b3" %}
+{% set checksum = "839bc07d5e3b9069180ad9c78bfb0b74ab7b4ccac9523a5b9d1d8aa0b154bab5" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - anaconda = binstar_client.scripts.cli:main
@@ -21,7 +20,7 @@ build:
     - conda-server = binstar_client.scripts.cli:main
 
 requirements:
-  build:
+  host:
     - python
     - pip
 
@@ -57,6 +56,7 @@ test:
 about:
   home: https://github.com/Anaconda-Platform/anaconda-client
   license: BSD 3-Clause
+  license_family: BSD
   license_file: LICENSE.md
   summary: Anaconda Cloud command line client library
   doc_url: https://docs.anaconda.com/anaconda-cloud/user-guide/getting-started/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-client" %}
-{% set version = "1.8.0" %}
-{% set checksum = "be97ef87be4e9076db91c0aaee4a4dc30e2527c8d87c63c8a0c12cd6fd269d95" %}
+{% set version = "1.9.0" %}
+{% set checksum = "78f64f3b3b556f5b939f742b69d50d4046f8dc3a5414c072447386ab9cb74deb" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,12 @@ requirements:
     - setuptools-scm >=7.1
     - hatch-requirements-txt
   run:
+    # Based on:
+    # requirements.txt, conda.recipe/meta.yaml, requirements-extra.txt
     - python
     - anaconda-anon-usage >=0.7.3
-    - anaconda-cli-base >=0.4.0
-    - anaconda-auth >=0.11.0
+    - anaconda-cli-base >=0.5.3
+    - anaconda-auth >=0.11.0 # minimum effectively required
     - conda-package-handling >=1.7.3
     - defusedxml >=0.7.1
     - nbformat >=4.4.0
@@ -42,6 +44,9 @@ requirements:
     - setuptools >=58.0.4
     - tqdm >=4.56.0
     - urllib3 >=1.26.4
+  run_constrained:
+    - anaconda-project >=0.9.1
+    - pillow >=8.2
 
 test:
   imports:
@@ -57,10 +62,10 @@ test:
   requires:
     - conda
     - pip
-    - pytest
-    - pytest-mock
-    - pillow >=8.2
-    - freezegun
+    - pytest >=8.4
+    - pytest-mock >=3.15
+    - pillow
+    - freezegun >=1.5
   commands:
     - pip check
     - export ANACONDA_CLI_FORCE_NEW=1  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.14.0" %}
+{% set version = "1.14.1" %}
 
 package:
   name: anaconda-client
   version: {{ version }}
 
 source:
-  url: https://github.com/Anaconda-Platform/anaconda-client/archive/{{ version }}.tar.gz
-  sha256: 2f3f26bff6753d5a55bc21736626080613a34848a1f4072afad5f56775a2bd85
+  url: https://github.com/anaconda/anaconda-client/archive/${{ version }}.tar.gz
+  sha256: 8a87e229021727bc357777a49fdc7b8d9299beb2dbe463dbe2b9092cf95d0684
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - python
     - anaconda-anon-usage >=0.7.3
     - anaconda-cli-base >=0.4.0
+    - anaconda-auth >=0.11.0
     - conda-package-handling >=1.7.3
     - defusedxml >=0.7.1
     - nbformat >=4.4.0
@@ -38,7 +39,6 @@ requirements:
     - setuptools >=58.0.4
     - tqdm >=4.56.0
     - urllib3 >=1.26.4
-    - anaconda-auth >=0.11.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ test:
     - conda
     - pip
     - pytest
+    - pytest-mock
     - pillow >=8.2
     - freezegun
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.13.1" %}
+{% set version = "1.14.0" %}
 
 package:
   name: anaconda-client
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-client/archive/{{ version }}.tar.gz
-  sha256: 96990e99d9c13e67e88c5a943936ae3596dcf6c4676175569e1b0aac3980cb12
+  sha256: 2f3f26bff6753d5a55bc21736626080613a34848a1f4072afad5f56775a2bd85
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,6 @@ build:
     - conda-server = binstar_client.scripts.cli:main
 
 requirements:
-  build:
-    - git  # [not win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,8 +85,8 @@ about:
   license_file: LICENSE.md
   summary: anaconda.org command line client library
   description: |
-    Anaconda-client is used to connect to and manage your Anaconda Cloud account, upload packages you have created
+    Anaconda-client is used to connect to and manage your packages on anaconda.org, upload packages you have created
     and generate access tokens to allow access to private packages.
   doc_url: https://docs.anaconda.com/anacondaorg/
-  doc_source_url: https://github.com/anaconda/anaconda-client/blob/master/README.md
+  doc_source_url: https://github.com/anaconda/anaconda-client/blob/main/README.md
   dev_url: https://github.com/anaconda/anaconda-client

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,10 @@ test:
     - anaconda org --help
     - python -c "import binstar_client; print(f'binstar_client.__version__ is {binstar_client.__version__}')"
     - python -c "import binstar_client; assert binstar_client.__version__ == \"{{ version }}\""
-    - pytest -v tests
+    - pytest -v tests # [not osx]
+    # Skip tests that require network access or cause "Too many open files" errors
+    # Only seen on CI, not replicated locally.
+    - pytest -v tests --ignore=tests/test_copy.py --ignore=tests/test_groups.py --ignore=tests/test_login.py --ignore=tests/test_update.py --ignore=tests/test_upload.py --ignore=tests/test_whoami.py --ignore=tests/utils/test_config.py -k "not test_download_arg_parsing and not test_write_env and not test_find_conda and not test_has_environment and not test_local_image" # [osx]
 
 about:
   home: https://anaconda.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - setuptools >=58.0.4
     - tqdm >=4.56.0
     - urllib3 >=1.26.4
+    - anaconda-auth >=0.11.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,72 +1,81 @@
-{% set name = "anaconda-client" %}
-{% set version = "1.9.0" %}
-{% set checksum = "78f64f3b3b556f5b939f742b69d50d4046f8dc3a5414c072447386ab9cb74deb" %}
+{% set version = "1.13.1" %}
 
 package:
-  name: {{ name }}
+  name: anaconda-client
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/Anaconda-Platform/anaconda-client/archive/{{ version }}.tar.gz
-  sha256: {{ checksum }}
+  sha256: 96990e99d9c13e67e88c5a943936ae3596dcf6c4676175569e1b0aac3980cb12
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps . -vv
   entry_points:
-    - anaconda = binstar_client.scripts.cli:main
     - binstar = binstar_client.scripts.cli:main
     - conda-server = binstar_client.scripts.cli:main
 
 requirements:
+  build:
+    - git  # [not win]
   host:
-    - python
     - pip
-    - wheel
+    - python
     - setuptools
-
   run:
     - python
-    - setuptools
-    - clyent >=1.2.0
+    - anaconda-anon-usage >=0.7.3
+    - anaconda-cli-base >=0.4.0
+    - conda-package-handling >=1.7.3
+    - defusedxml >=0.7.1
     - nbformat >=4.4.0
-    - pyyaml >=3.12
+    - platformdirs >=3.10.0,<5.0
     - python-dateutil >=2.6.1
-    - pytz
-    - requests >=2.9.1
-    - six
+    - pytz >=2021.3
+    - pyyaml >=3.12
+    - requests >=2.20.0
+    - requests-toolbelt >=0.9.1
+    - setuptools >=58.0.4
+    - tqdm >=4.56.0
+    - urllib3 >=1.26.4
 
 test:
   imports:
     - binstar_client
     - binstar_client.commands
     - binstar_client.inspect_package
-    - binstar_client.inspect_package.tests
     - binstar_client.mixins
     - binstar_client.scripts
-    - binstar_client.tests
     - binstar_client.utils
     - binstar_client.utils.notebook
-    - binstar_client.utils.notebook.tests
+  source_files:
+    - tests
   requires:
+    - conda
     - pip
+    - pytest
+    - pillow >=8.2
+    - freezegun
   commands:
     - pip check
-    - anaconda --help
-    - binstar --help
-    - conda-server --help
+    - export ANACONDA_CLI_FORCE_NEW=1  # [unix]
+    - set ANACONDA_CLI_FORCE_NEW=1     # [win]
+    - anaconda -h
+    - anaconda -V
+    - anaconda org --help
+    - python -c "import binstar_client; print(f'binstar_client.__version__ is {binstar_client.__version__}')"
+    - python -c "import binstar_client; assert binstar_client.__version__ == \"{{ version }}\""
+    - pytest -v tests
 
 about:
-  home: https://github.com/Anaconda-Platform/anaconda-client
-  license: BSD 3-Clause
+  home: https://anaconda.org
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md
-  summary: Anaconda Cloud command line client library
-  doc_url: https://docs.anaconda.com/anaconda-cloud/user-guide/getting-started/
-  dev_url: https://github.com/Anaconda-Platform/anaconda-client
-
-extra:
-  recipe-maintainers:
-    - jakirkham
-    - goanpeca
+  summary: anaconda.org command line client library
+  description: |
+    Anaconda-client is used to connect to and manage your Anaconda Cloud account, upload packages you have created
+    and generate access tokens to allow access to private packages.
+  doc_url: https://docs.anaconda.com/anacondaorg/
+  doc_source_url: https://github.com/anaconda/anaconda-client/blob/master/README.md
+  dev_url: https://github.com/anaconda/anaconda-client

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,10 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
+    - hatchling
+    - hatch-vcs >=0.3
+    - setuptools-scm >=7.1
+    - hatch-requirements-txt
   run:
     - python
     - anaconda-anon-usage >=0.7.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.10
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
@@ -26,10 +26,10 @@ requirements:
   run:
     # Based on:
     # requirements.txt, conda.recipe/meta.yaml, requirements-extra.txt
-    - python
+    - python >=3.10
     - anaconda-anon-usage >=0.7.3
-    - anaconda-cli-base >=0.5.3
-    - anaconda-auth >=0.11.0 # minimum effectively required
+    - anaconda-cli-base >=0.7.0
+    - anaconda-auth >=0.12.3
     - conda-package-handling >=1.7.3
     - defusedxml >=0.7.1
     - nbformat >=4.4.0


### PR DESCRIPTION
## Summary

Update for `anaconda-client=1.14.1`. This is a patch release with minor bug fixes.

* [Release Notes](https://github.com/anaconda/anaconda-client/releases/tag/1.14.1)
* [conda-forge update](https://github.com/conda-forge/anaconda-client-feedstock/pull/62)

### Dependency updates

* Update minimum: `python >=3.10`
* Update minimum: `anaconda-auth >=0.12.3`
* Update minimum: `anaconda-cli-base >=0.7.0`